### PR TITLE
[cpanminus]: Add inspec tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
-results
+results/
+inspec.lock

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# cpanminus
+
+cpanminus is a script to get, unpack, build and install modules from CPAN and does nothing else.
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,15 +1,72 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.cpanminus?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=203&branchName=master)
+
 # cpanminus
 
-cpanminus is a script to get, unpack, build and install modules from CPAN and does nothing else.
+cpanminus is a script to get, unpack, build and install modules from CPAN and does nothing else.  See [documentation](https://metacpan.org/pod/release/MIYAGAWA/App-cpanminus-0.9929/lib/App/cpanminus.pm)
 
 ## Maintainers
 
-* The Habitat Maintainers: <humans@habitat.sh>
+* The Core Planners: <chef-core-planners@chef.io>
 
 ## Type of Package
 
 Binary package
 
-## Usage
+### Use as Dependency
 
-*TODO: Add instructions for usage*
+Binary packages can be set as runtime or build time dependencies. See [Defining your dependencies](https://www.habitat.sh/docs/developing-packages/developing-packages/#sts=Define%20Your%20Dependencies) for more information.
+
+To add core/cpanminus as a dependency, you can add one of the following to your plan file.
+
+##### Buildtime Dependency
+
+> pkg_build_deps=(core/cpanminus)
+
+##### Runtime dependency
+
+> pkg_deps=(core/cpanminus)
+
+### Use as Tool
+
+#### Installation
+
+To install this plan, you should run the following commands to first install, and then link the binaries this plan creates.
+
+``hab pkg install core/cpanminus --binlink``
+
+will add the following binary to the PATH:
+
+* /bin/cpanm
+
+For example:
+
+```bash
+$ hab pkg install core/cpanminus --binlink
+» Installing core/cpanminus
+☁ Determining latest version of core/cpanminus in the 'stable' channel
+→ Found newer installed version (core/cpanminus/1.7044/20200819134135) than remote version (core/cpanminus/1.7044/20200404014441)
+→ Using core/cpanminus/1.7044/20200819134135
+★ Install of core/cpanminus/1.7044/20200819134135 complete with 0 new packages installed.
+» Binlinking cpanm from core/cpanminus/1.7044/20200819134135 into /bin
+★ Binlinked cpanm from core/cpanminus/1.7044/20200819134135 to /bin/cpanm
+```
+
+#### Using an example binary
+
+You can now use the binary as normal.  For example:
+
+``/bin/cpanm --help`` or ``cpanm --help``
+
+```bash
+$ cpanm --help
+Usage: cpanm [options] Module [...]
+
+Options:
+  -v,--verbose              Turns on chatty output
+  -q,--quiet                Turns off the most output
+  --interactive             Turns on interactive configure (required for Task:: modules)
+  -f,--force                force install
+  -n,--notest               Do not run unit tests
+  --test-only               Run tests only, do not install
+  -S,--sudo                 sudo to run install commands
+```

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+plan_name: 'cpanminus'

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -15,4 +15,4 @@ resources:
 
 # Execute the stages from the main pipeline template
 stages:
-  - template: azure-pipelines.yml@plan_builder
+  - template: azure-pipelines-package-install.yml@plan_builder

--- a/botanist.yml
+++ b/botanist.yml
@@ -1,0 +1,4 @@
+---
+owners:
+  - "@smacfarlane"
+  - "@habitat-sh/habitat-core-plans-maintainers"

--- a/controls/cpanminus_exists.rb
+++ b/controls/cpanminus_exists.rb
@@ -15,7 +15,6 @@ control 'core-plans-cpanminus-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
 
   command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "cpanm")

--- a/controls/cpanminus_exists.rb
+++ b/controls/cpanminus_exists.rb
@@ -1,0 +1,26 @@
+title 'Tests to confirm cpanminus exists'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'cpanminus')
+
+control 'core-plans-cpanminus-exists' do
+  impact 1.0
+  title 'Ensure cpanminus exists'
+  desc '
+  Verify cpanminus by ensuring bin/cpanm 
+  (1) exists and
+  (2) is executable'
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "cpanm")
+  describe file(command_full_path) do
+    it { should exist }
+    it { should be_executable }
+  end
+end

--- a/controls/cpanminus_works.rb
+++ b/controls/cpanminus_works.rb
@@ -1,0 +1,30 @@
+title 'Tests to confirm cpanminus works as expected'
+
+plan_origin = ENV['HAB_ORIGIN']
+plan_name = input('plan_name', value: 'cpanminus')
+
+control 'core-plans-cpanminus-works' do
+  impact 1.0
+  title 'Ensure cpanminus works as expected'
+  desc '
+  Verify cpanminus by ensuring that
+  (1) its installation directory exists 
+  (2) it returns the expected version
+  '
+  
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
+  end
+  
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "bin", "cpanm")
+  describe command("#{command_full_path} --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /cpanm.*(?<=version)\s+(#{plan_pkg_version})/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/cpanminus_works.rb
+++ b/controls/cpanminus_works.rb
@@ -16,7 +16,6 @@ control 'core-plans-cpanminus-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stderr') { should be_empty }
   end
   
   plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
@@ -25,6 +24,5 @@ control 'core-plans-cpanminus-works' do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /cpanm.*(?<=version)\s+(#{plan_pkg_version})/ }
-    its('stderr') { should be_empty }
   end
 end

--- a/hooks/run
+++ b/hooks/run
@@ -1,8 +1,0 @@
-#!/bin/bash
-
-exec 2>&1
-
-while true; do
-  echo "Sleeping ..."
-  sleep 10
-done

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,7 +1,7 @@
-name: {plan}
-title: Habitat Core Plan {plan}
+name: cpanminus
+title: Habitat Core Plan cpanminus
 maintainer: "The Core Planners <chef-core-planners@chef.io>"
-summary: InSpec controls for testing Habitat Core Plan {plan}
+summary: InSpec controls for testing Habitat Core Plan cpanminus
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 4.18.108'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,40 @@
+pkg_name=cpanminus
+pkg_version=1.7044
+pkg_origin=core
+pkg_license=('Artistic-2.0')
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="cpanminus is a script to get, unpack, build and install modules from CPAN and does nothing else."
+pkg_upstream_url=http://cpanmin.us
+pkg_source=https://github.com/miyagawa/${pkg_name}/archive/${pkg_version}.tar.gz
+pkg_filename=${pkg_name}-${pkg_version}.tar.gz
+pkg_dirname=${pkg_name}-${pkg_version}
+pkg_shasum=a5407a85c2f3dda74dfc2241c68dafb9951f2a6eeada0a0eea9e7238a482c195
+pkg_build_deps=(
+  core/coreutils
+  core/curl
+  core/gcc
+  core/local-lib
+  core/make
+  core/perl
+)
+pkg_deps=(
+  core/glibc
+  core/local-lib
+  core/perl
+)
+pkg_lib_dirs=(lib)
+pkg_bin_dirs=(bin)
+
+do_build() {
+  return 0
+}
+
+do_install() {
+  # Load local::lib into our current perl include chain
+  eval "$(perl -I"$(pkg_path_for core/local-lib)"/lib/perl5 -Mlocal::lib="$(pkg_path_for core/local-lib)")"
+  # Create a new lib dir in our pacakge for cpanm to house all of its libs
+  eval "$(perl -Mlocal::lib="${pkg_prefix}")"
+
+  # cpanm prioritizes the local::lib location for an install dir
+  curl -L http://cpanmin.us | perl - App::cpanminus
+}


### PR DESCRIPTION
Also remove .hooks/run

tests all passing in hab studio:

```rspec
» Installing chef/inspec
☁ Determining latest version of chef/inspec in the 'stable' channel
→ Using chef/inspec/4.22.8/20200804103652
★ Install of chef/inspec/4.22.8/20200804103652 complete with 0 new packages installed.

Profile: Habitat Core Plan cpanminus (cpanminus)
Version: 0.1.0
Target:  local://

  ✔  core-plans-cpanminus-exists: Ensure cpanminus exists
     ✔  Command: `hab pkg path core/cpanminus` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/cpanminus` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/cpanminus` stderr is expected to be empty
     ✔  File /hab/pkgs/core/cpanminus/1.7044/20200819134135/bin/cpanm is expected to exist
     ✔  File /hab/pkgs/core/cpanminus/1.7044/20200819134135/bin/cpanm is expected to be executable
  ✔  core-plans-cpanminus-works: Ensure cpanminus works as expected
     ✔  Command: `hab pkg path core/cpanminus` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/cpanminus` stdout is expected not to be empty
     ✔  Command: `hab pkg path core/cpanminus` stderr is expected to be empty
     ✔  Command: `/hab/pkgs/core/cpanminus/1.7044/20200819134135/bin/cpanm --version` exit_status is expected to eq 0
     ✔  Command: `/hab/pkgs/core/cpanminus/1.7044/20200819134135/bin/cpanm --version` stdout is expected not to be empty
     ✔  Command: `/hab/pkgs/core/cpanminus/1.7044/20200819134135/bin/cpanm --version` stdout is expected to match /cpanm.*(?<=version)\s+(1.7044)/
     ✔  Command: `/hab/pkgs/core/cpanminus/1.7044/20200819134135/bin/cpanm --version` stderr is expected to be empty


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 12 successful, 0 failures, 0 skipped
```
